### PR TITLE
feat: add quantity +/- controls, fix icon, fix vector DB

### DIFF
--- a/app/(app)/actions.ts
+++ b/app/(app)/actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { eq, and, or, isNull, ilike, desc, sql } from 'drizzle-orm';
+import { eq, and, or, isNull, ilike, desc, sql, inArray } from 'drizzle-orm';
 import { getCurrentUserId } from '@/lib/auth';
 import { db } from '@/lib/db';
 import { profiles, shoppingItems, products, categories } from '@/lib/db/schema';
@@ -113,11 +113,11 @@ export async function searchProducts(
               usageCount: products.usageCount,
             })
             .from(products)
-            .where(sql`${products.id} IN ${semanticIds}`);
+            .where(inArray(products.id, semanticIds));
         }
       }
-    } catch {
-      // Semantic search failed — return ILIKE results only
+    } catch (err) {
+      console.error('[searchProducts] Semantic search failed:', err);
     }
   }
 
@@ -139,7 +139,7 @@ export async function searchProducts(
         icon: categories.icon,
       })
       .from(categories)
-      .where(sql`${categories.id} IN ${categoryIds}`);
+      .where(inArray(categories.id, categoryIds));
 
     cats.forEach((c) => {
       categoryMap[c.id] = { name: c.name, icon: c.icon };
@@ -249,8 +249,8 @@ export async function addProduct(
           if (similar.length > 0 && similar[0].categoryId) {
             embeddingCategoryId = similar[0].categoryId;
           }
-        } catch {
-          // Embedding generation failed — fall back to uncategorized
+        } catch (err) {
+          console.error('[addProduct] Embedding generation failed:', err);
         }
       }
 
@@ -377,6 +377,35 @@ export async function classifyProduct(
 
   revalidatePath('/');
   notifyListUpdate(profile.familyId);
+  return { success: true };
+}
+
+export async function updateQuantity(
+  itemId: string,
+  newQuantity: number,
+): Promise<{ success: boolean; error?: string }> {
+  if (newQuantity <= 0) {
+    return { success: false, error: 'Ilość musi być większa od 0' };
+  }
+
+  const userId = await getCurrentUserId();
+  if (!userId) {
+    return { success: false, error: 'Nie jesteś zalogowany' };
+  }
+
+  const [profile] = await db
+    .select({ familyId: profiles.familyId })
+    .from(profiles)
+    .where(eq(profiles.id, userId))
+    .limit(1);
+
+  await db
+    .update(shoppingItems)
+    .set({ quantity: newQuantity.toString() })
+    .where(eq(shoppingItems.id, itemId));
+
+  revalidatePath('/');
+  if (profile?.familyId) notifyListUpdate(profile.familyId);
   return { success: true };
 }
 

--- a/app/api/embeddings/test/route.ts
+++ b/app/api/embeddings/test/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { sql } from 'drizzle-orm';
+import { isEmbeddingConfigured, generateEmbedding, findSimilarProducts } from '@/lib/embeddings';
+
+/**
+ * GET /api/embeddings/test
+ *
+ * Diagnostics endpoint for verifying vector database and embedding setup.
+ * Protected by AUTH_SECRET.
+ *
+ * Usage:
+ *   curl https://your-app.vercel.app/api/embeddings/test \
+ *     -H "Authorization: Bearer YOUR_AUTH_SECRET"
+ */
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get('authorization');
+  const expectedToken = process.env.AUTH_SECRET;
+
+  if (!expectedToken || authHeader !== `Bearer ${expectedToken}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const report: Record<string, unknown> = {};
+
+  // 1. Check OpenAI API key
+  report.openai_key_configured = isEmbeddingConfigured();
+
+  // 2. Check pgvector extension
+  try {
+    const extResult = await db.execute(
+      sql`SELECT 1 FROM pg_extension WHERE extname = 'vector'`,
+    );
+    report.pgvector_installed = extResult.rows.length > 0;
+  } catch (err) {
+    report.pgvector_installed = false;
+    report.pgvector_error = err instanceof Error ? err.message : String(err);
+  }
+
+  // 3. Check embedding column on products table
+  try {
+    await db.execute(sql`SELECT embedding FROM products LIMIT 0`);
+    report.embedding_column_exists = true;
+  } catch (err) {
+    report.embedding_column_exists = false;
+    report.embedding_column_error = err instanceof Error ? err.message : String(err);
+  }
+
+  // 4. Count products with and without embeddings
+  try {
+    const totalResult = await db.execute(
+      sql`SELECT COUNT(*)::int AS total FROM products`,
+    );
+    const withEmbeddingResult = await db.execute(
+      sql`SELECT COUNT(*)::int AS with_embedding FROM products WHERE embedding IS NOT NULL`,
+    );
+    report.products_total = totalResult.rows[0]?.total ?? 0;
+    report.products_with_embedding = withEmbeddingResult.rows[0]?.with_embedding ?? 0;
+  } catch (err) {
+    report.products_count_error = err instanceof Error ? err.message : String(err);
+  }
+
+  // 5. Test live embedding generation + similarity search (only if everything looks good)
+  if (report.openai_key_configured && report.pgvector_installed && report.embedding_column_exists) {
+    try {
+      const testEmbedding = await generateEmbedding('mleko');
+      report.embedding_generation = 'ok';
+      report.embedding_dimensions = testEmbedding.length;
+
+      const similar = await findSimilarProducts(testEmbedding, null, {
+        threshold: 0.5,
+        limit: 3,
+      });
+      report.similarity_search = 'ok';
+      report.similarity_test_results = similar.map((s) => ({
+        name: s.name,
+        similarity: s.similarity.toFixed(3),
+      }));
+    } catch (err) {
+      report.live_test_error = err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  const allOk =
+    report.openai_key_configured &&
+    report.pgvector_installed &&
+    report.embedding_column_exists;
+
+  return NextResponse.json({ ok: allOk, ...report });
+}

--- a/components/shopping/shopping-item.tsx
+++ b/components/shopping/shopping-item.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useOptimistic, useState, useTransition } from 'react';
-import { Check } from 'lucide-react';
-import { toggleShoppingItem, classifyProduct } from '@/app/(app)/actions';
+import { Check, Minus, Plus } from 'lucide-react';
+import { toggleShoppingItem, classifyProduct, updateQuantity } from '@/app/(app)/actions';
 import { CategoryPicker } from './category-picker';
 
 type CategoryData = {
@@ -43,6 +43,16 @@ function formatRelativeTime(dateStr: string): string {
   });
 }
 
+function getQuantityStep(unit: string): number {
+  if (unit === 'kg' || unit === 'l') return 0.5;
+  if (unit === 'g' || unit === 'ml') return 100;
+  return 1;
+}
+
+function formatQuantity(qty: number): string {
+  return qty % 1 === 0 ? qty.toFixed(0) : qty.toString();
+}
+
 export function ShoppingItem({
   id,
   productName,
@@ -58,14 +68,38 @@ export function ShoppingItem({
   categories,
 }: ShoppingItemProps) {
   const [isPending, startTransition] = useTransition();
+  const [isQtyPending, startQtyTransition] = useTransition();
   const [optimisticChecked, setOptimisticChecked] = useOptimistic(isChecked);
+  const [optimisticQuantity, setOptimisticQuantity] = useOptimistic(quantity);
   const [classifyError, setClassifyError] = useState<string | null>(null);
+
+  const step = getQuantityStep(unit);
+  const minQuantity = step;
 
   const handleToggle = () => {
     const newChecked = !optimisticChecked;
     startTransition(async () => {
       setOptimisticChecked(newChecked);
       await toggleShoppingItem(id, newChecked);
+    });
+  };
+
+  const handleIncrement = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    const newQty = parseFloat((optimisticQuantity + step).toFixed(2));
+    startQtyTransition(async () => {
+      setOptimisticQuantity(newQty);
+      await updateQuantity(id, newQty);
+    });
+  };
+
+  const handleDecrement = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (optimisticQuantity <= minQuantity) return;
+    const newQty = parseFloat(Math.max(minQuantity, optimisticQuantity - step).toFixed(2));
+    startQtyTransition(async () => {
+      setOptimisticQuantity(newQty);
+      await updateQuantity(id, newQty);
     });
   };
 
@@ -130,27 +164,51 @@ export function ShoppingItem({
           )}
         </div>
 
-        {/* Product name + quantity/unit */}
-        <span className="flex flex-1 items-baseline gap-2">
-          <span
-            className={`text-base transition-all duration-150 ${
-              optimisticChecked
-                ? 'text-text-disabled line-through'
-                : 'text-text-primary'
-            }`}
-          >
-            {productName}
-          </span>
-          {(quantity !== 1 || unit !== 'szt') && (
-            <span
-              className={`text-sm transition-all duration-150 ${
-                optimisticChecked ? 'text-text-disabled line-through' : 'text-text-tertiary'
-              }`}
-            >
-              {quantity % 1 === 0 ? quantity.toFixed(0) : quantity.toString()} {unit}
-            </span>
-          )}
+        {/* Product name */}
+        <span
+          className={`flex-1 text-base transition-all duration-150 ${
+            optimisticChecked
+              ? 'text-text-disabled line-through'
+              : 'text-text-primary'
+          }`}
+        >
+          {productName}
         </span>
+
+        {/* Quantity controls (hidden when checked) */}
+        {!optimisticChecked ? (
+          <div
+            className={`flex shrink-0 items-center gap-1 ${isQtyPending ? 'opacity-60' : ''}`}
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => e.stopPropagation()}
+          >
+            <button
+              onClick={handleDecrement}
+              disabled={optimisticQuantity <= minQuantity}
+              className="flex h-7 w-7 items-center justify-center rounded-full text-mint-500 transition-colors hover:bg-mint-100 active:bg-mint-200 disabled:text-text-disabled"
+              aria-label="Zmniejsz ilość"
+            >
+              <Minus size={13} strokeWidth={2.5} />
+            </button>
+            <span className="min-w-[3.5rem] text-center text-sm text-text-secondary">
+              {formatQuantity(optimisticQuantity)} {unit}
+            </span>
+            <button
+              onClick={handleIncrement}
+              className="flex h-7 w-7 items-center justify-center rounded-full text-mint-500 transition-colors hover:bg-mint-100 active:bg-mint-200"
+              aria-label="Zwiększ ilość"
+            >
+              <Plus size={13} strokeWidth={2.5} />
+            </button>
+          </div>
+        ) : (
+          /* Show quantity as plain text when checked */
+          (quantity !== 1 || unit !== 'szt') && (
+            <span className="shrink-0 text-sm text-text-disabled line-through">
+              {formatQuantity(quantity)} {unit}
+            </span>
+          )
+        )}
 
         {/* Meta info */}
         <span className="shrink-0 text-xs text-text-tertiary">{metaInfo}</span>

--- a/public/icons/icon.svg
+++ b/public/icons/icon.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
   <rect width="512" height="512" rx="96" fill="#4ade80"/>
   <g transform="translate(256, 256) scale(1.8)" stroke="white" stroke-width="14" fill="none" stroke-linecap="round" stroke-linejoin="round">
-    <circle cx="-48" cy="78" r="6" fill="white"/>
-    <circle cx="63" cy="78" r="6" fill="white"/>
+    <circle cx="-63" cy="33" r="6" fill="white"/>
+    <circle cx="5" cy="33" r="6" fill="white"/>
     <path d="M-110 -78h14l18.6 86.9a14 14 0 0 0 14 11h68.5a14 14 0 0 0 13.7-11L32 -26h-120.2"/>
   </g>
 </svg>


### PR DESCRIPTION
- Add +/- buttons to shopping list items for inline quantity changes
  (step: 1 for szt, 0.5 for kg/l, 100 for g/ml; min = step)
- Add updateQuantity server action with optimistic UI updates
- Fix vector DB IN-clause bugs: replace sql template with inArray()
  for semanticIds and categoryIds queries in searchProducts
- Add /api/embeddings/test diagnostic endpoint (Bearer-protected)
  to verify pgvector, embedding column, OpenAI key, and live search
- Fix SVG icon: reposition cart wheels from cy=78 to cy=33 and align
  cx values with cart bottom corners (-63, 5) so wheels sit under cart

https://claude.ai/code/session_015JXBoRW1mJi1aW5v3o7p52