### PR TITLE
Add per-family REST API (/api/v1) for external shopping-list agents

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -23,3 +23,12 @@ NEXT_PUBLIC_APP_URL=https://cartlo.vercel.app
 # OpenAI API (embeddings for smart product categorization — optional)
 # Get your key at https://platform.openai.com/api-keys
 OPENAI_API_KEY=sk-your-openai-api-key
+
+# ---------------------------------------------------------------------------
+# Agent REST API (/api/v1) — no server env var needed; per-family API keys
+# are generated in Settings and stored (hashed) in the database.
+# The AGENT consuming the API keeps its key in its own .env, e.g.:
+#   CARTLO_API_URL=https://cartlo.vercel.app
+#   CARTLO_API_KEY=cartlo_sk_...
+# See docs/api.md for endpoints and examples.
+# ---------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ Aplikacja dostepna pod [http://localhost:3000](http://localhost:3000).
 
 \* Bez `OPENAI_API_KEY` aplikacja dziala normalnie, ale bez inteligentnej kategoryzacji i wyszukiwania semantycznego.
 
+## API dla agenta (/api/v1)
+
+Aplikacja wystawia REST API pozwalajace zewnetrznemu agentowi (np. asystentowi AI) czytac i edytowac liste zakupow rodziny. Klucz API generuje sie per rodzina w **Ustawienia → Klucz API (Agent AI)**; pozycje dodane przez API sa podpisane profilem „Agent". Szczegoly i przyklady: [docs/api.md](docs/api.md). Wymagana migracja: `drizzle/migration_api_keys.sql` (lub `npm run db:push`).
+
 ## Inteligentna kategoryzacja produktow
 
 System wykorzystuje embeddingi wektorowe (OpenAI + pgvector) do automatycznej klasyfikacji produktow:

--- a/app/(app)/actions.ts
+++ b/app/(app)/actions.ts
@@ -1,17 +1,17 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { eq, and, or, isNull, ilike, desc, sql, inArray } from 'drizzle-orm';
+import { eq, and, or, isNull, ilike, desc, inArray } from 'drizzle-orm';
 import { getCurrentUserId } from '@/lib/auth';
 import { db } from '@/lib/db';
 import { profiles, shoppingItems, products, categories } from '@/lib/db/schema';
 import { notifyListUpdate } from '@/lib/pusher/server';
+import { addShoppingItem, updateShoppingItem } from '@/lib/shopping/service';
 import {
   generateEmbedding,
   findSimilarProducts,
-  saveProductEmbedding,
-  upsertProductEmbedding,
   isEmbeddingConfigured,
+  upsertProductEmbedding,
 } from '@/lib/embeddings';
 
 export async function toggleShoppingItem(
@@ -33,17 +33,14 @@ export async function toggleShoppingItem(
     return { success: false, error: 'Nie należysz do rodziny' };
   }
 
-  await db
-    .update(shoppingItems)
-    .set({
-      isChecked,
-      checkedBy: isChecked ? userId : null,
-      checkedAt: isChecked ? new Date() : null,
-    })
-    .where(and(eq(shoppingItems.id, itemId), eq(shoppingItems.familyId, profile.familyId)));
+  await updateShoppingItem({
+    familyId: profile.familyId,
+    itemId,
+    patch: { isChecked },
+    actorProfileId: userId,
+  });
 
   revalidatePath('/');
-  if (profile?.familyId) notifyListUpdate(profile.familyId);
   return { success: true };
 }
 
@@ -189,119 +186,20 @@ export async function addProduct(
     return { success: false, error: 'Nie należysz do rodziny' };
   }
 
-  // Check for duplicates on active list
-  const existing = await db
-    .select({ id: shoppingItems.id })
-    .from(shoppingItems)
-    .where(
-      and(
-        eq(shoppingItems.familyId, profile.familyId),
-        eq(shoppingItems.isChecked, false),
-        ilike(shoppingItems.productName, trimmed),
-      ),
-    )
-    .limit(1);
+  const result = await addShoppingItem({
+    familyId: profile.familyId,
+    profileId: userId,
+    productName: trimmed,
+    quantity,
+    unit,
+    categoryId: knownCategoryId,
+  });
 
-  if (existing.length > 0) {
+  if (!result.ok) {
     return { success: false, error: 'Ten produkt już jest na liście' };
   }
 
-  // Determine category: use known category if provided, otherwise auto-detect
-  let categoryId: string | null = knownCategoryId ?? null;
-
-  if (knownCategoryId === undefined) {
-    // Look up product in products table for auto-categorization
-    const [knownProduct] = await db
-      .select({
-        id: products.id,
-        categoryId: products.categoryId,
-        usageCount: products.usageCount,
-      })
-      .from(products)
-      .where(
-        and(
-          ilike(products.name, trimmed),
-          or(
-            isNull(products.familyId),
-            eq(products.familyId, profile.familyId),
-          ),
-        ),
-      )
-      .limit(1);
-
-    if (knownProduct) {
-      categoryId = knownProduct.categoryId;
-      // Increment usage_count for better autocomplete sorting
-      await db
-        .update(products)
-        .set({ usageCount: knownProduct.usageCount + 1 })
-        .where(eq(products.id, knownProduct.id));
-    } else {
-      // Product not found by exact match — try semantic search via embeddings
-      let embeddingCategoryId: string | null = null;
-      let productEmbedding: number[] | null = null;
-
-      if (isEmbeddingConfigured()) {
-        try {
-          productEmbedding = await generateEmbedding(trimmed);
-          const similar = await findSimilarProducts(
-            productEmbedding,
-            profile.familyId,
-            { threshold: 0.8, limit: 1, requireCategory: true },
-          );
-
-          if (similar.length > 0 && similar[0].categoryId) {
-            embeddingCategoryId = similar[0].categoryId;
-          }
-        } catch (err) {
-          console.error('[addProduct] Embedding generation failed:', err);
-        }
-      }
-
-      categoryId = embeddingCategoryId;
-
-      // Add as new product (with embedding if available)
-      try {
-        const [newProduct] = await db
-          .insert(products)
-          .values({
-            name: trimmed,
-            categoryId,
-            familyId: profile.familyId,
-            usageCount: 1,
-          })
-          .onConflictDoUpdate({
-            target: [products.name, products.familyId],
-            set: { categoryId, usageCount: sql`${products.usageCount} + 1` },
-          })
-          .returning({ id: products.id });
-
-        // Save embedding for the new product (non-blocking)
-        if (isEmbeddingConfigured() && newProduct) {
-          if (productEmbedding) {
-            saveProductEmbedding(newProduct.id, productEmbedding).catch(() => {});
-          } else {
-            upsertProductEmbedding(newProduct.id, trimmed).catch(() => {});
-          }
-        }
-      } catch {
-        // Product upsert failed — continue with shopping item insertion
-      }
-    }
-  }
-
-  // Insert shopping item
-  await db.insert(shoppingItems).values({
-    familyId: profile.familyId,
-    productName: trimmed,
-    categoryId,
-    quantity: quantity.toString(),
-    unit,
-    addedBy: userId,
-  });
-
   revalidatePath('/');
-  notifyListUpdate(profile.familyId);
   return { success: true };
 }
 
@@ -329,7 +227,12 @@ export async function classifyProduct(
   await db
     .update(shoppingItems)
     .set({ categoryId })
-    .where(and(eq(shoppingItems.id, itemId), eq(shoppingItems.familyId, profile.familyId)));
+    .where(
+      and(
+        eq(shoppingItems.id, itemId),
+        eq(shoppingItems.familyId, profile.familyId),
+      ),
+    );
 
   // Upsert product — teach the system for future auto-categorization
   const [existingProduct] = await db
@@ -403,13 +306,18 @@ export async function updateQuantity(
     .where(eq(profiles.id, userId))
     .limit(1);
 
-  await db
-    .update(shoppingItems)
-    .set({ quantity: newQuantity.toString() })
-    .where(eq(shoppingItems.id, itemId));
+  if (!profile?.familyId) {
+    return { success: false, error: 'Nie należysz do rodziny' };
+  }
+
+  await updateShoppingItem({
+    familyId: profile.familyId,
+    itemId,
+    patch: { quantity: newQuantity },
+    actorProfileId: userId,
+  });
 
   revalidatePath('/');
-  if (profile?.familyId) notifyListUpdate(profile.familyId);
   return { success: true };
 }
 

--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -1,8 +1,9 @@
 import { redirect } from 'next/navigation';
-import { eq, or, isNull, asc } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import { getCurrentUserId } from '@/lib/auth';
 import { db } from '@/lib/db';
-import { profiles, shoppingItems, categories, } from '@/lib/db/schema';
+import { profiles } from '@/lib/db/schema';
+import { getShoppingList } from '@/lib/shopping/service';
 import { ShoppingList } from '@/components/shopping/shopping-list';
 
 export default async function ListPage() {
@@ -17,64 +18,35 @@ export default async function ListPage() {
 
   if (!profile?.familyId) redirect('/onboarding');
 
-  // Fetch shopping items for the family
-  const items = await db
-    .select({
-      id: shoppingItems.id,
-      product_name: shoppingItems.productName,
-      category_id: shoppingItems.categoryId,
-      quantity: shoppingItems.quantity,
-      unit: shoppingItems.unit,
-      is_checked: shoppingItems.isChecked,
-      added_by: shoppingItems.addedBy,
-      checked_by: shoppingItems.checkedBy,
-      checked_at: shoppingItems.checkedAt,
-      created_at: shoppingItems.createdAt,
-    })
-    .from(shoppingItems)
-    .where(eq(shoppingItems.familyId, profile.familyId))
-    .orderBy(asc(shoppingItems.productName));
+  const { items, categories, memberNames } = await getShoppingList(
+    profile.familyId,
+  );
 
-  // Fetch categories
-  const cats = await db
-    .select({
-      id: categories.id,
-      name: categories.name,
-      icon: categories.icon,
-      sort_order: categories.sortOrder,
-    })
-    .from(categories)
-    .where(
-      or(
-        isNull(categories.familyId),
-        eq(categories.familyId, profile.familyId),
-      ),
-    )
-    .orderBy(asc(categories.sortOrder));
-
-  // Fetch family member names for meta info
-  const members = await db
-    .select({ id: profiles.id, display_name: profiles.displayName })
-    .from(profiles)
-    .where(eq(profiles.familyId, profile.familyId));
-
-  // Build member name lookup
-  const memberNames: Record<string, string> = {};
-  members.forEach((m) => {
-    memberNames[m.id] = m.display_name;
-  });
-
-  // Serialize dates to strings for client components
+  // Serialize for client components (snake_case props, dates as strings)
   const serializedItems = items.map((item) => ({
-    ...item,
-    checked_at: item.checked_at?.toISOString() ?? null,
-    created_at: item.created_at.toISOString(),
+    id: item.id,
+    product_name: item.productName,
+    category_id: item.categoryId,
+    quantity: item.quantity,
+    unit: item.unit,
+    is_checked: item.isChecked,
+    added_by: item.addedBy,
+    checked_by: item.checkedBy,
+    checked_at: item.checkedAt?.toISOString() ?? null,
+    created_at: item.createdAt.toISOString(),
+  }));
+
+  const serializedCategories = categories.map((c) => ({
+    id: c.id,
+    name: c.name,
+    icon: c.icon,
+    sort_order: c.sortOrder,
   }));
 
   return (
     <ShoppingList
       items={serializedItems}
-      categories={cats}
+      categories={serializedCategories}
       memberNames={memberNames}
       familyId={profile.familyId}
     />

--- a/app/(app)/settings/actions.ts
+++ b/app/(app)/settings/actions.ts
@@ -2,11 +2,20 @@
 
 import { redirect } from 'next/navigation';
 import { revalidatePath } from 'next/cache';
-import { eq, and, or, isNull, ilike, asc, desc, sql } from 'drizzle-orm';
+import { randomBytes } from 'crypto';
+import { eq, and, or, isNull, ilike, desc, sql } from 'drizzle-orm';
 import bcrypt from 'bcryptjs';
 import { signOut as authSignOut, getCurrentUserId } from '@/lib/auth';
 import { db } from '@/lib/db';
-import { profiles, users, products, categories, shoppingItems } from '@/lib/db/schema';
+import {
+  profiles,
+  users,
+  products,
+  categories,
+  shoppingItems,
+  apiKeys,
+} from '@/lib/db/schema';
+import { generateApiKeyString, hashApiKey } from '@/lib/api/auth';
 
 // ---------------------------------------------------------------------------
 // Sign out
@@ -42,10 +51,7 @@ export async function updateDisplayName(
   const userId = await getCurrentUserId();
   if (!userId) redirect('/login');
 
-  await db
-    .update(profiles)
-    .set({ displayName })
-    .where(eq(profiles.id, userId));
+  await db.update(profiles).set({ displayName }).where(eq(profiles.id, userId));
 
   revalidatePath('/', 'layout');
   return { error: null, success: true };
@@ -156,7 +162,8 @@ export async function sendInviteEmail(
   const smtpPass = process.env.SMTP_PASS;
   if (!smtpUser || !smtpPass) {
     return {
-      error: 'Wysyłanie emaili nie jest skonfigurowane. Użyj linku zaproszenia.',
+      error:
+        'Wysyłanie emaili nie jest skonfigurowane. Użyj linku zaproszenia.',
       success: false,
     };
   }
@@ -215,6 +222,141 @@ export async function sendInviteEmail(
 }
 
 // ---------------------------------------------------------------------------
+// API key for the agent REST API (/api/v1)
+// ---------------------------------------------------------------------------
+
+/**
+ * Find or create the family's system "Agent" profile that API writes are
+ * attributed to. Profiles require a users row (PK/FK), so the agent gets a
+ * synthetic user with an unusable password hash (bcrypt.compare always fails
+ * against a non-bcrypt string) and an internal, per-family email.
+ */
+async function ensureAgentProfile(familyId: string): Promise<string> {
+  const agentEmail = `agent+${familyId}@agent.cartlo.internal`;
+
+  let [agentUser] = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.email, agentEmail))
+    .limit(1);
+
+  if (!agentUser) {
+    [agentUser] = await db
+      .insert(users)
+      .values({
+        email: agentEmail,
+        passwordHash: randomBytes(32).toString('hex'),
+      })
+      .returning({ id: users.id });
+  }
+
+  const [agentProfile] = await db
+    .select({ id: profiles.id, familyId: profiles.familyId })
+    .from(profiles)
+    .where(eq(profiles.id, agentUser.id))
+    .limit(1);
+
+  if (!agentProfile) {
+    await db.insert(profiles).values({
+      id: agentUser.id,
+      familyId,
+      displayName: 'Agent',
+    });
+  } else if (agentProfile.familyId !== familyId) {
+    await db
+      .update(profiles)
+      .set({ familyId })
+      .where(eq(profiles.id, agentUser.id));
+  }
+
+  return agentUser.id;
+}
+
+export async function generateApiKey(): Promise<{
+  success: boolean;
+  error?: string;
+  apiKey?: string;
+}> {
+  try {
+    const userId = await getCurrentUserId();
+    if (!userId) return { success: false, error: 'Nie jesteś zalogowany' };
+
+    const [profile] = await db
+      .select({ familyId: profiles.familyId })
+      .from(profiles)
+      .where(eq(profiles.id, userId))
+      .limit(1);
+
+    if (!profile?.familyId) {
+      return { success: false, error: 'Nie należysz do rodziny' };
+    }
+
+    const agentProfileId = await ensureAgentProfile(profile.familyId);
+
+    // One active key per family — generating a new one revokes the old
+    await db
+      .update(apiKeys)
+      .set({ revokedAt: new Date() })
+      .where(
+        and(eq(apiKeys.familyId, profile.familyId), isNull(apiKeys.revokedAt)),
+      );
+
+    const apiKey = generateApiKeyString();
+    await db.insert(apiKeys).values({
+      familyId: profile.familyId,
+      agentProfileId,
+      keyHash: hashApiKey(apiKey),
+      keyPrefix: apiKey.slice(0, 16),
+    });
+
+    revalidatePath('/settings');
+    return { success: true, apiKey };
+  } catch (error) {
+    console.error('generateApiKey error:', error);
+    return {
+      success: false,
+      error: 'Wystąpił błąd podczas generowania klucza',
+    };
+  }
+}
+
+export async function revokeApiKey(): Promise<{
+  success: boolean;
+  error?: string;
+}> {
+  try {
+    const userId = await getCurrentUserId();
+    if (!userId) return { success: false, error: 'Nie jesteś zalogowany' };
+
+    const [profile] = await db
+      .select({ familyId: profiles.familyId })
+      .from(profiles)
+      .where(eq(profiles.id, userId))
+      .limit(1);
+
+    if (!profile?.familyId) {
+      return { success: false, error: 'Nie należysz do rodziny' };
+    }
+
+    await db
+      .update(apiKeys)
+      .set({ revokedAt: new Date() })
+      .where(
+        and(eq(apiKeys.familyId, profile.familyId), isNull(apiKeys.revokedAt)),
+      );
+
+    revalidatePath('/settings');
+    return { success: true };
+  } catch (error) {
+    console.error('revokeApiKey error:', error);
+    return {
+      success: false,
+      error: 'Wystąpił błąd podczas unieważniania klucza',
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Search products for category management
 // ---------------------------------------------------------------------------
 export type ProductWithCategory = {
@@ -253,7 +395,10 @@ export async function searchProductsForSettings(
       .where(
         and(
           ilike(products.name, `%${trimmed}%`),
-          or(isNull(products.familyId), eq(products.familyId, profile.familyId)),
+          or(
+            isNull(products.familyId),
+            eq(products.familyId, profile.familyId),
+          ),
         ),
       )
       .orderBy(desc(products.usageCount))
@@ -286,8 +431,12 @@ export async function searchProductsForSettings(
       id: p.id,
       name: p.name,
       categoryId: p.categoryId,
-      categoryName: p.categoryId ? (categoryMap[p.categoryId]?.name ?? null) : null,
-      categoryIcon: p.categoryId ? (categoryMap[p.categoryId]?.icon ?? null) : null,
+      categoryName: p.categoryId
+        ? (categoryMap[p.categoryId]?.name ?? null)
+        : null,
+      categoryIcon: p.categoryId
+        ? (categoryMap[p.categoryId]?.icon ?? null)
+        : null,
     }));
   } catch (error) {
     console.error('searchProductsForSettings error:', error);
@@ -312,16 +461,24 @@ export async function updateProductCategory(
       .where(eq(profiles.id, userId))
       .limit(1);
 
-    if (!profile?.familyId) return { success: false, error: 'Nie należysz do rodziny' };
+    if (!profile?.familyId)
+      return { success: false, error: 'Nie należysz do rodziny' };
 
     // Get product to verify access and get name
     const [product] = await db
-      .select({ id: products.id, name: products.name, familyId: products.familyId })
+      .select({
+        id: products.id,
+        name: products.name,
+        familyId: products.familyId,
+      })
       .from(products)
       .where(
         and(
           eq(products.id, productId),
-          or(isNull(products.familyId), eq(products.familyId, profile.familyId)),
+          or(
+            isNull(products.familyId),
+            eq(products.familyId, profile.familyId),
+          ),
         ),
       )
       .limit(1);

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -1,8 +1,14 @@
 import { redirect } from 'next/navigation';
-import { eq, or, asc } from 'drizzle-orm';
+import { eq, and, or, asc, isNull } from 'drizzle-orm';
 import { getCurrentUserId } from '@/lib/auth';
 import { db } from '@/lib/db';
-import { profiles, users, families, categories } from '@/lib/db/schema';
+import {
+  profiles,
+  users,
+  families,
+  categories,
+  apiKeys,
+} from '@/lib/db/schema';
 import { SettingsClient } from './settings-client';
 import { ProductCategories } from '@/components/settings/product-categories';
 
@@ -39,6 +45,18 @@ export default async function SettingsPage() {
     .where(eq(families.id, profile.familyId))
     .limit(1);
 
+  const [activeApiKey] = await db
+    .select({
+      keyPrefix: apiKeys.keyPrefix,
+      createdAt: apiKeys.createdAt,
+      lastUsedAt: apiKeys.lastUsedAt,
+    })
+    .from(apiKeys)
+    .where(
+      and(eq(apiKeys.familyId, profile.familyId), isNull(apiKeys.revokedAt)),
+    )
+    .limit(1);
+
   const allCategories = await db
     .select({
       id: categories.id,
@@ -60,6 +78,15 @@ export default async function SettingsPage() {
         displayName={profile.displayName}
         email={user.email}
         inviteCode={family?.inviteCode ?? ''}
+        apiKeyInfo={
+          activeApiKey
+            ? {
+                keyPrefix: activeApiKey.keyPrefix,
+                createdAt: activeApiKey.createdAt.toISOString(),
+                lastUsedAt: activeApiKey.lastUsedAt?.toISOString() ?? null,
+              }
+            : null
+        }
       />
       <div className="mx-auto max-w-lg px-4 pb-6 -mt-2">
         <ProductCategories categories={allCategories} />

--- a/app/(app)/settings/settings-client.tsx
+++ b/app/(app)/settings/settings-client.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useActionState, useState, useTransition } from 'react';
-import { Sun, Moon, Monitor, Mail } from 'lucide-react';
+import { Sun, Moon, Monitor, Mail, KeyRound } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { useTheme } from '@/hooks/use-theme';
@@ -10,10 +10,18 @@ import {
   updateDisplayName,
   changePassword,
   sendInviteEmail,
+  generateApiKey,
+  revokeApiKey,
   type UpdateProfileState,
   type ChangePasswordState,
   type InviteEmailState,
 } from './actions';
+
+export type ApiKeyInfo = {
+  keyPrefix: string;
+  createdAt: string;
+  lastUsedAt: string | null;
+};
 
 const profileInitial: UpdateProfileState = { error: null, success: false };
 const passwordInitial: ChangePasswordState = { error: null, success: false };
@@ -29,10 +37,12 @@ export function SettingsClient({
   displayName,
   email,
   inviteCode,
+  apiKeyInfo,
 }: {
   displayName: string;
   email: string;
   inviteCode: string;
+  apiKeyInfo: ApiKeyInfo | null;
 }) {
   const [showLogoutConfirm, setShowLogoutConfirm] = useState(false);
   const [isLoggingOut, startLogout] = useTransition();
@@ -274,6 +284,14 @@ export function SettingsClient({
         </div>
       </section>
 
+      {/* API key section */}
+      <section className="mb-8">
+        <h2 className="mb-3 text-lg font-bold text-text-primary">
+          Klucz API (Agent AI)
+        </h2>
+        <ApiKeyCard apiKeyInfo={apiKeyInfo} />
+      </section>
+
       {/* Theme section */}
       <section className="mb-8">
         <h2 className="mb-3 text-lg font-bold text-text-primary">Wygląd</h2>
@@ -337,6 +355,159 @@ export function SettingsClient({
           )}
         </div>
       </section>
+    </div>
+  );
+}
+
+function ApiKeyCard({ apiKeyInfo }: { apiKeyInfo: ApiKeyInfo | null }) {
+  const [isPending, startTransition] = useTransition();
+  const [newKey, setNewKey] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [showRevokeConfirm, setShowRevokeConfirm] = useState(false);
+
+  const handleGenerate = () => {
+    setError(null);
+    startTransition(async () => {
+      const result = await generateApiKey();
+      if (result.success && result.apiKey) {
+        setNewKey(result.apiKey);
+      } else {
+        setError(result.error ?? 'Wystąpił błąd');
+      }
+    });
+  };
+
+  const handleRevoke = () => {
+    setError(null);
+    setShowRevokeConfirm(false);
+    startTransition(async () => {
+      const result = await revokeApiKey();
+      if (result.success) {
+        setNewKey(null);
+      } else {
+        setError(result.error ?? 'Wystąpił błąd');
+      }
+    });
+  };
+
+  const handleCopy = async () => {
+    if (!newKey) return;
+    try {
+      await navigator.clipboard.writeText(newKey);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Fallback silently
+    }
+  };
+
+  const formatDate = (iso: string) =>
+    new Date(iso).toLocaleDateString('pl-PL', {
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+    });
+
+  return (
+    <div className="rounded-2xl border border-border bg-surface p-4 shadow-sm">
+      <p className="mb-3 text-xs text-text-tertiary">
+        Klucz pozwala zewnętrznemu agentowi (np. asystentowi AI) czytać i
+        edytować listę zakupów Twojej rodziny przez API. Pozycje dodane przez
+        API są podpisane jako &bdquo;Agent&rdquo;.
+      </p>
+
+      {newKey ? (
+        <div className="mb-3 rounded-lg border border-warning-border bg-warning-bg p-3">
+          <p className="mb-2 text-xs font-semibold text-warning-text">
+            Skopiuj klucz teraz — nie pokażemy go ponownie!
+          </p>
+          <div className="flex items-center gap-2">
+            <code className="flex-1 truncate rounded bg-surface px-2 py-1.5 text-xs text-text-primary">
+              {newKey}
+            </code>
+            <Button
+              onClick={handleCopy}
+              variant="outline"
+              size="sm"
+              className="shrink-0 rounded-lg text-xs"
+            >
+              {copied ? 'Skopiowano!' : 'Kopiuj'}
+            </Button>
+          </div>
+        </div>
+      ) : apiKeyInfo ? (
+        <div className="mb-3 flex items-center gap-2 rounded-lg bg-surface-raised px-3 py-2">
+          <KeyRound size={16} className="shrink-0 text-text-tertiary" />
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm text-text-primary">
+              {apiKeyInfo.keyPrefix}…
+            </p>
+            <p className="text-xs text-text-tertiary">
+              Utworzony {formatDate(apiKeyInfo.createdAt)}
+              {apiKeyInfo.lastUsedAt
+                ? ` · ostatnio użyty ${formatDate(apiKeyInfo.lastUsedAt)}`
+                : ' · nieużywany'}
+            </p>
+          </div>
+        </div>
+      ) : null}
+
+      {error && (
+        <div className="mb-3 rounded-lg bg-error-bg px-3 py-2 text-sm text-error-text">
+          {error}
+        </div>
+      )}
+
+      {showRevokeConfirm ? (
+        <div className="rounded-lg border border-warning-border bg-warning-bg p-3">
+          <p className="mb-2 text-sm text-warning-text">
+            Agent straci dostęp do listy. Kontynuować?
+          </p>
+          <div className="flex gap-2">
+            <Button
+              onClick={handleRevoke}
+              disabled={isPending}
+              size="sm"
+              className="rounded-lg bg-error-text text-xs text-white hover:bg-error-text/90"
+            >
+              Tak, unieważnij
+            </Button>
+            <Button
+              onClick={() => setShowRevokeConfirm(false)}
+              variant="ghost"
+              size="sm"
+              className="rounded-lg text-xs"
+            >
+              Anuluj
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex gap-2">
+          <Button
+            onClick={handleGenerate}
+            disabled={isPending}
+            className="h-11 flex-1 rounded-xl bg-mint-400 text-[15px] font-semibold text-white shadow-sm hover:bg-mint-500 active:bg-mint-600"
+          >
+            {isPending
+              ? 'Generowanie...'
+              : apiKeyInfo || newKey
+                ? 'Wygeneruj nowy klucz'
+                : 'Wygeneruj klucz'}
+          </Button>
+          {(apiKeyInfo || newKey) && (
+            <Button
+              onClick={() => setShowRevokeConfirm(true)}
+              disabled={isPending}
+              variant="outline"
+              className="h-11 rounded-xl border-border text-[15px] font-semibold text-error-text hover:bg-error-bg"
+            >
+              Unieważnij
+            </Button>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/app/(app)/templates/actions.ts
+++ b/app/(app)/templates/actions.ts
@@ -13,6 +13,7 @@ import {
   categories,
 } from '@/lib/db/schema';
 import { notifyListUpdate } from '@/lib/pusher/server';
+import { removeDiacritics } from '@/lib/utils';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -58,16 +59,9 @@ const CATEGORY_UNIT_MAP: Record<string, string> = {
   Package: 'szt',
 };
 
-function getDefaultUnitForCategory(
-  categoryIcon: string | null,
-): string {
+function getDefaultUnitForCategory(categoryIcon: string | null): string {
   if (!categoryIcon) return 'szt';
   return CATEGORY_UNIT_MAP[categoryIcon] ?? 'szt';
-}
-
-/** Strip diacritics so that e.g. "Nabiał" matches "Nabial". */
-function removeDiacritics(str: string): string {
-  return str.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
 }
 
 // ---------------------------------------------------------------------------
@@ -205,7 +199,12 @@ export async function deleteTemplate(
 
   const result = await db
     .delete(templates)
-    .where(and(eq(templates.id, templateId), eq(templates.familyId, profile.familyId)))
+    .where(
+      and(
+        eq(templates.id, templateId),
+        eq(templates.familyId, profile.familyId),
+      ),
+    )
     .returning({ id: templates.id });
 
   if (result.length === 0)
@@ -238,7 +237,12 @@ export async function renameTemplate(
   const result = await db
     .update(templates)
     .set({ name: trimmed })
-    .where(and(eq(templates.id, templateId), eq(templates.familyId, profile.familyId)))
+    .where(
+      and(
+        eq(templates.id, templateId),
+        eq(templates.familyId, profile.familyId),
+      ),
+    )
     .returning({ id: templates.id });
 
   if (result.length === 0)
@@ -267,11 +271,15 @@ export async function duplicateTemplate(
   const [source] = await db
     .select({ id: templates.id, name: templates.name })
     .from(templates)
-    .where(and(eq(templates.id, templateId), eq(templates.familyId, profile.familyId)))
+    .where(
+      and(
+        eq(templates.id, templateId),
+        eq(templates.familyId, profile.familyId),
+      ),
+    )
     .limit(1);
 
-  if (!source)
-    return { success: false, error: 'Szablon nie istnieje' };
+  if (!source) return { success: false, error: 'Szablon nie istnieje' };
 
   // Create copy
   const [newTemplate] = await db
@@ -330,7 +338,11 @@ export async function duplicateTemplate(
   const categoryMap: Record<string, { name: string; icon: string }> = {};
   if (categoryIds.length > 0) {
     const cats = await db
-      .select({ id: categories.id, name: categories.name, icon: categories.icon })
+      .select({
+        id: categories.id,
+        name: categories.name,
+        icon: categories.icon,
+      })
       .from(categories)
       .where(sql`${categories.id} IN ${categoryIds}`);
     cats.forEach((c) => {
@@ -469,7 +481,12 @@ export async function removeTemplateItem(
     .select({ id: templateItems.id })
     .from(templateItems)
     .innerJoin(templates, eq(templateItems.templateId, templates.id))
-    .where(and(eq(templateItems.id, itemId), eq(templates.familyId, profile.familyId)))
+    .where(
+      and(
+        eq(templateItems.id, itemId),
+        eq(templates.familyId, profile.familyId),
+      ),
+    )
     .limit(1);
 
   if (!item) return { success: false, error: 'Element nie istnieje' };
@@ -506,7 +523,12 @@ export async function updateTemplateItem(
     .select({ id: templateItems.id })
     .from(templateItems)
     .innerJoin(templates, eq(templateItems.templateId, templates.id))
-    .where(and(eq(templateItems.id, itemId), eq(templates.familyId, profile.familyId)))
+    .where(
+      and(
+        eq(templateItems.id, itemId),
+        eq(templates.familyId, profile.familyId),
+      ),
+    )
     .limit(1);
 
   if (!item) return { success: false, error: 'Element nie istnieje' };
@@ -589,7 +611,12 @@ export async function reorderTemplateItems(
   const [template] = await db
     .select({ id: templates.id })
     .from(templates)
-    .where(and(eq(templates.id, templateId), eq(templates.familyId, profile.familyId)))
+    .where(
+      and(
+        eq(templates.id, templateId),
+        eq(templates.familyId, profile.familyId),
+      ),
+    )
     .limit(1);
 
   if (!template) return { success: false, error: 'Szablon nie istnieje' };
@@ -599,7 +626,9 @@ export async function reorderTemplateItems(
     db
       .update(templateItems)
       .set({ sortOrder: index })
-      .where(and(eq(templateItems.id, id), eq(templateItems.templateId, templateId))),
+      .where(
+        and(eq(templateItems.id, id), eq(templateItems.templateId, templateId)),
+      ),
   );
 
   await Promise.all(updates);
@@ -627,7 +656,12 @@ export async function sortTemplateItemsByCategory(
   const [tmpl] = await db
     .select({ id: templates.id })
     .from(templates)
-    .where(and(eq(templates.id, templateId), eq(templates.familyId, profile.familyId)))
+    .where(
+      and(
+        eq(templates.id, templateId),
+        eq(templates.familyId, profile.familyId),
+      ),
+    )
     .limit(1);
 
   if (!tmpl) return { success: false, error: 'Szablon nie istnieje' };
@@ -719,7 +753,10 @@ export async function importTemplate(
     return { success: false, error: 'Nazwa szablonu nie może być pusta' };
 
   if (!Array.isArray(payload.items) || payload.items.length === 0)
-    return { success: false, error: 'Szablon musi zawierać przynajmniej jeden produkt' };
+    return {
+      success: false,
+      error: 'Szablon musi zawierać przynajmniej jeden produkt',
+    };
 
   const validUnits = new Set(['szt', 'g', 'kg', 'ml', 'l']);
 
@@ -746,12 +783,23 @@ export async function importTemplate(
       ),
     );
 
-  const categoryByName: Record<string, { id: string; name: string; icon: string }> = {};
+  const categoryByName: Record<
+    string,
+    { id: string; name: string; icon: string }
+  > = {};
   allCategories.forEach((c) => {
     // Index by both the original name and the diacritic-stripped version
     // so imports work regardless of whether names use Polish characters or not.
-    categoryByName[c.name.toLowerCase()] = { id: c.id, name: c.name, icon: c.icon };
-    categoryByName[removeDiacritics(c.name).toLowerCase()] = { id: c.id, name: c.name, icon: c.icon };
+    categoryByName[c.name.toLowerCase()] = {
+      id: c.id,
+      name: c.name,
+      icon: c.icon,
+    };
+    categoryByName[removeDiacritics(c.name).toLowerCase()] = {
+      id: c.id,
+      name: c.name,
+      icon: c.icon,
+    };
   });
 
   // Create template
@@ -761,29 +809,31 @@ export async function importTemplate(
     .returning({ id: templates.id, createdAt: templates.createdAt });
 
   // Insert items
-  const itemsToInsert = payload.items.map((item, index) => {
-    const productName = item.product_name?.trim();
-    if (!productName) return null;
+  const itemsToInsert = payload.items
+    .map((item, index) => {
+      const productName = item.product_name?.trim();
+      if (!productName) return null;
 
-    // Try exact match first, then diacritic-stripped match
-    const matchedCategory = item.category
-      ? categoryByName[item.category.toLowerCase()]
-        ?? categoryByName[removeDiacritics(item.category).toLowerCase()]
-        ?? null
-      : null;
+      // Try exact match first, then diacritic-stripped match
+      const matchedCategory = item.category
+        ? (categoryByName[item.category.toLowerCase()] ??
+          categoryByName[removeDiacritics(item.category).toLowerCase()] ??
+          null)
+        : null;
 
-    const unit = item.unit && validUnits.has(item.unit) ? item.unit : 'szt';
-    const quantity = item.quantity && item.quantity > 0 ? item.quantity : 1;
+      const unit = item.unit && validUnits.has(item.unit) ? item.unit : 'szt';
+      const quantity = item.quantity && item.quantity > 0 ? item.quantity : 1;
 
-    return {
-      templateId: template.id,
-      productName,
-      categoryId: matchedCategory?.id ?? null,
-      quantity: quantity.toString(),
-      unit,
-      sortOrder: index,
-    };
-  }).filter(Boolean) as {
+      return {
+        templateId: template.id,
+        productName,
+        categoryId: matchedCategory?.id ?? null,
+        quantity: quantity.toString(),
+        unit,
+        sortOrder: index,
+      };
+    })
+    .filter(Boolean) as {
     templateId: string;
     productName: string;
     categoryId: string | null;
@@ -866,11 +916,15 @@ export async function useTemplate(templateId: string): Promise<{
   const [tmplCheck] = await db
     .select({ id: templates.id })
     .from(templates)
-    .where(and(eq(templates.id, templateId), eq(templates.familyId, profile.familyId)))
+    .where(
+      and(
+        eq(templates.id, templateId),
+        eq(templates.familyId, profile.familyId),
+      ),
+    )
     .limit(1);
 
-  if (!tmplCheck)
-    return { success: false, error: 'Szablon nie istnieje' };
+  if (!tmplCheck) return { success: false, error: 'Szablon nie istnieje' };
 
   const items = await db
     .select({

--- a/app/api/v1/items/[id]/route.ts
+++ b/app/api/v1/items/[id]/route.ts
@@ -1,0 +1,147 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { authenticateApiKey, unauthorized } from '@/lib/api/auth';
+import { buildCategoryById, toApiItem } from '@/lib/api/serialize';
+import {
+  parseJsonBody,
+  validateQuantity,
+  validateUnit,
+  UUID_REGEX,
+} from '@/lib/api/validate';
+import {
+  buildCategoryNameIndex,
+  deleteShoppingItem,
+  getFamilyCategories,
+  getMemberNames,
+  matchCategoryByName,
+  updateShoppingItem,
+  type UpdateItemPatch,
+} from '@/lib/shopping/service';
+
+const notFound = () =>
+  NextResponse.json({ error: 'Item not found' }, { status: 404 });
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const ctx = await authenticateApiKey(request);
+  if (!ctx) return unauthorized();
+
+  const { id } = await params;
+  // Bad UUID gets the same 404 as another family's item — no existence leak
+  if (!UUID_REGEX.test(id)) return notFound();
+
+  const body = await parseJsonBody(request);
+  if (!body) {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const patch: UpdateItemPatch = {};
+
+  if (body.product_name !== undefined) {
+    if (
+      typeof body.product_name !== 'string' ||
+      body.product_name.trim().length === 0
+    ) {
+      return NextResponse.json(
+        { error: 'product_name must be a non-empty string' },
+        { status: 400 },
+      );
+    }
+    if (body.product_name.trim().length > 100) {
+      return NextResponse.json(
+        { error: 'product_name must be at most 100 characters' },
+        { status: 400 },
+      );
+    }
+    patch.productName = body.product_name.trim();
+  }
+
+  if (body.quantity !== undefined) {
+    const quantityError = validateQuantity(body.quantity);
+    if (quantityError) {
+      return NextResponse.json({ error: quantityError }, { status: 400 });
+    }
+    patch.quantity = body.quantity as number;
+  }
+
+  if (body.unit !== undefined) {
+    const unitError = validateUnit(body.unit);
+    if (unitError) {
+      return NextResponse.json({ error: unitError }, { status: 400 });
+    }
+    patch.unit = body.unit as string;
+  }
+
+  if (body.is_checked !== undefined) {
+    if (typeof body.is_checked !== 'boolean') {
+      return NextResponse.json(
+        { error: 'is_checked must be a boolean' },
+        { status: 400 },
+      );
+    }
+    patch.isChecked = body.is_checked;
+  }
+
+  const cats = await getFamilyCategories(ctx.familyId);
+
+  if (body.category !== undefined) {
+    if (body.category === null) {
+      patch.categoryId = null;
+    } else if (typeof body.category !== 'string') {
+      return NextResponse.json(
+        { error: 'category must be a string or null' },
+        { status: 400 },
+      );
+    } else {
+      // Unknown category name → uncategorized, not an error
+      patch.categoryId =
+        matchCategoryByName(buildCategoryNameIndex(cats), body.category)?.id ??
+        null;
+    }
+  }
+
+  if (Object.keys(patch).length === 0) {
+    return NextResponse.json(
+      {
+        error:
+          'At least one of product_name, quantity, unit, category, is_checked is required',
+      },
+      { status: 400 },
+    );
+  }
+
+  const item = await updateShoppingItem({
+    familyId: ctx.familyId,
+    itemId: id,
+    patch,
+    actorProfileId: ctx.agentProfileId,
+  });
+
+  if (!item) return notFound();
+
+  const memberNames = await getMemberNames(ctx.familyId);
+  return NextResponse.json({
+    item: toApiItem(item, buildCategoryById(cats), memberNames),
+  });
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const ctx = await authenticateApiKey(request);
+  if (!ctx) return unauthorized();
+
+  const { id } = await params;
+  if (!UUID_REGEX.test(id)) return notFound();
+
+  const deleted = await deleteShoppingItem({
+    familyId: ctx.familyId,
+    itemId: id,
+  });
+
+  if (!deleted) return notFound();
+
+  return NextResponse.json({ deleted: true });
+}

--- a/app/api/v1/items/bulk/route.ts
+++ b/app/api/v1/items/bulk/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { authenticateApiKey, unauthorized } from '@/lib/api/auth';
+import { buildCategoryById, toApiItem } from '@/lib/api/serialize';
+import { parseJsonBody, validateItemInput } from '@/lib/api/validate';
+import {
+  bulkAddShoppingItems,
+  getFamilyCategories,
+  getMemberNames,
+  type BulkItemInput,
+} from '@/lib/shopping/service';
+
+const MAX_BULK_ITEMS = 100;
+
+export async function POST(request: NextRequest) {
+  const ctx = await authenticateApiKey(request);
+  if (!ctx) return unauthorized();
+
+  const body = await parseJsonBody(request);
+  if (!body) {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  if (!Array.isArray(body.items) || body.items.length === 0) {
+    return NextResponse.json(
+      { error: 'items must be a non-empty array' },
+      { status: 400 },
+    );
+  }
+  if (body.items.length > MAX_BULK_ITEMS) {
+    return NextResponse.json(
+      { error: `items must contain at most ${MAX_BULK_ITEMS} entries` },
+      { status: 400 },
+    );
+  }
+
+  const inputs: BulkItemInput[] = [];
+  for (let i = 0; i < body.items.length; i++) {
+    const entry = body.items[i];
+    if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
+      return NextResponse.json(
+        { error: `items[${i}] must be an object` },
+        { status: 400 },
+      );
+    }
+    const validated = validateItemInput(entry as Record<string, unknown>);
+    if (!validated.ok) {
+      return NextResponse.json(
+        { error: `items[${i}]: ${validated.error}` },
+        { status: 400 },
+      );
+    }
+    inputs.push({
+      productName: validated.value.productName,
+      categoryName: validated.value.categoryName,
+      quantity: validated.value.quantity,
+      unit: validated.value.unit,
+    });
+  }
+
+  const { added, skipped } = await bulkAddShoppingItems({
+    familyId: ctx.familyId,
+    profileId: ctx.agentProfileId,
+    items: inputs,
+  });
+
+  const [cats, memberNames] = await Promise.all([
+    getFamilyCategories(ctx.familyId),
+    getMemberNames(ctx.familyId),
+  ]);
+  const categoryById = buildCategoryById(cats);
+
+  return NextResponse.json(
+    {
+      added: added.length,
+      skipped,
+      items: added.map((item) => toApiItem(item, categoryById, memberNames)),
+    },
+    { status: 201 },
+  );
+}

--- a/app/api/v1/items/route.ts
+++ b/app/api/v1/items/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { authenticateApiKey, unauthorized } from '@/lib/api/auth';
+import { buildCategoryById, toApiItem } from '@/lib/api/serialize';
+import { parseJsonBody, validateItemInput } from '@/lib/api/validate';
+import {
+  addShoppingItem,
+  buildCategoryNameIndex,
+  getFamilyCategories,
+  getMemberNames,
+  matchCategoryByName,
+} from '@/lib/shopping/service';
+
+export async function POST(request: NextRequest) {
+  const ctx = await authenticateApiKey(request);
+  if (!ctx) return unauthorized();
+
+  const body = await parseJsonBody(request);
+  if (!body) {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const validated = validateItemInput(body);
+  if (!validated.ok) {
+    return NextResponse.json({ error: validated.error }, { status: 400 });
+  }
+  const input = validated.value;
+
+  const cats = await getFamilyCategories(ctx.familyId);
+
+  // Explicit category name: match it (unknown name → uncategorized, not an
+  // error). No category field at all → auto-detect from the products table.
+  let categoryId: string | null | undefined = undefined;
+  if (input.categoryName !== undefined) {
+    categoryId = input.categoryName
+      ? (matchCategoryByName(buildCategoryNameIndex(cats), input.categoryName)
+          ?.id ?? null)
+      : null;
+  }
+
+  const result = await addShoppingItem({
+    familyId: ctx.familyId,
+    profileId: ctx.agentProfileId,
+    productName: input.productName,
+    quantity: input.quantity,
+    unit: input.unit,
+    categoryId,
+  });
+
+  if (!result.ok) {
+    return NextResponse.json(
+      { error: 'Item already on the list', item_id: result.itemId },
+      { status: 409 },
+    );
+  }
+
+  const memberNames = await getMemberNames(ctx.familyId);
+  return NextResponse.json(
+    { item: toApiItem(result.item, buildCategoryById(cats), memberNames) },
+    { status: 201 },
+  );
+}

--- a/app/api/v1/list/route.ts
+++ b/app/api/v1/list/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { authenticateApiKey, unauthorized } from '@/lib/api/auth';
+import { buildCategoryById, toApiItem } from '@/lib/api/serialize';
+import { getShoppingList } from '@/lib/shopping/service';
+
+export async function GET(request: NextRequest) {
+  const ctx = await authenticateApiKey(request);
+  if (!ctx) return unauthorized();
+
+  const { items, categories, memberNames } = await getShoppingList(
+    ctx.familyId,
+  );
+  const categoryById = buildCategoryById(categories);
+
+  return NextResponse.json({
+    family_id: ctx.familyId,
+    items: items.map((item) => toApiItem(item, categoryById, memberNames)),
+    categories: categories.map((c) => ({
+      id: c.id,
+      name: c.name,
+      icon: c.icon,
+    })),
+  });
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,133 @@
+# Cartlo Agent API (v1)
+
+REST API pozwalające zewnętrznemu agentowi (np. asystentowi AI) czytać i
+edytować listę zakupów rodziny. Uwierzytelnianie odbywa się kluczem API
+generowanym per rodzina — klucz sam wyznacza rodzinę, na której działa.
+
+## Uwierzytelnianie
+
+1. W aplikacji wejdź w **Ustawienia → Klucz API (Agent AI)** i wygeneruj klucz
+   (`cartlo_sk_...`). Klucz jest pokazywany tylko raz.
+2. Każde żądanie wysyłaj z nagłówkiem:
+
+   ```
+   Authorization: Bearer cartlo_sk_...
+   ```
+
+Wygenerowanie nowego klucza unieważnia poprzedni. Klucz można też unieważnić
+bez tworzenia nowego. Pozycje dodane przez API są podpisane profilem „Agent".
+
+Przykładowy plik `.env` agenta:
+
+```env
+CARTLO_API_URL=https://cartlo.vercel.app
+CARTLO_API_KEY=cartlo_sk_twoj-klucz
+```
+
+## Endpointy
+
+Wszystkie odpowiedzi to JSON. Błędy mają format `{ "error": "..." }` z
+odpowiednim kodem HTTP (`401` brak/zły klucz, `400` złe dane, `404` brak
+pozycji, `409` duplikat).
+
+| Metoda | Ścieżka | Opis |
+|---|---|---|
+| `GET` | `/api/v1/list` | Aktualna lista zakupów + dostępne kategorie |
+| `POST` | `/api/v1/items` | Dodanie pojedynczej pozycji |
+| `PATCH` | `/api/v1/items/{id}` | Edycja pozycji (nazwa, ilość, jednostka, kategoria, odhaczenie) |
+| `DELETE` | `/api/v1/items/{id}` | Usunięcie pozycji |
+| `POST` | `/api/v1/items/bulk` | Dodanie całej listy naraz (max 100 pozycji) |
+
+### Pola pozycji (żądania)
+
+| Pole | Typ | Opis |
+|---|---|---|
+| `product_name` | string | Wymagane przy dodawaniu, 1–100 znaków |
+| `quantity` | number | Opcjonalne, > 0 i ≤ 9999.99 (domyślnie 1) |
+| `unit` | string | Opcjonalne, jedno z: `szt`, `g`, `kg`, `ml`, `l` (domyślnie `szt`) |
+| `category` | string | Opcjonalne, nazwa kategorii (wielkość liter i polskie znaki bez znaczenia, np. `nabial` = `Nabiał`). Nieznana nazwa → pozycja bez kategorii. Brak pola przy `POST /items` → automatyczna kategoryzacja |
+| `is_checked` | boolean | Tylko `PATCH` — odhacza/przywraca pozycję |
+
+### Przykłady (curl)
+
+```bash
+BASE=https://cartlo.vercel.app
+KEY=cartlo_sk_twoj-klucz
+
+# Aktualna lista
+curl -s "$BASE/api/v1/list" -H "Authorization: Bearer $KEY"
+
+# Dodanie pozycji
+curl -s -X POST "$BASE/api/v1/items" \
+  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
+  -d '{"product_name":"Mleko","quantity":2,"unit":"l","category":"Nabiał"}'
+
+# Edycja pozycji (odhaczenie)
+curl -s -X PATCH "$BASE/api/v1/items/ID_POZYCJI" \
+  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
+  -d '{"is_checked":true}'
+
+# Zmiana ilości
+curl -s -X PATCH "$BASE/api/v1/items/ID_POZYCJI" \
+  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
+  -d '{"quantity":3,"unit":"szt"}'
+
+# Usunięcie pozycji
+curl -s -X DELETE "$BASE/api/v1/items/ID_POZYCJI" \
+  -H "Authorization: Bearer $KEY"
+
+# Dodanie całej listy naraz
+curl -s -X POST "$BASE/api/v1/items/bulk" \
+  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
+  -d '{"items":[
+    {"product_name":"Chleb","category":"Pieczywo"},
+    {"product_name":"Masło","quantity":1,"unit":"szt","category":"Nabiał"},
+    {"product_name":"Pomidory","quantity":500,"unit":"g","category":"Warzywa i owoce"}
+  ]}'
+```
+
+### Odpowiedzi
+
+`GET /api/v1/list`:
+
+```json
+{
+  "family_id": "…",
+  "items": [
+    {
+      "id": "…",
+      "product_name": "Mleko",
+      "category_id": "…",
+      "category_name": "Nabiał",
+      "category_icon": "Milk",
+      "quantity": 2,
+      "unit": "l",
+      "is_checked": false,
+      "added_by_name": "Agent",
+      "checked_by_name": null,
+      "created_at": "2026-07-23T10:00:00.000Z",
+      "checked_at": null
+    }
+  ],
+  "categories": [{ "id": "…", "name": "Nabiał", "icon": "Milk" }]
+}
+```
+
+`POST /items` i `PATCH /items/{id}` zwracają `{ "item": { … } }` (ten sam
+kształt co wyżej). `POST /items` zwraca `409` z `item_id`, gdy nieodhaczona
+pozycja o tej nazwie już istnieje. `DELETE` zwraca `{ "deleted": true }`.
+
+`POST /items/bulk` pomija duplikaty (względem aktywnej listy i wewnątrz
+żądania) zamiast zgłaszać błąd:
+
+```json
+{ "added": 2, "skipped": ["Chleb"], "items": [ … ] }
+```
+
+## Uwagi
+
+- Zmiany wykonane przez API są natychmiast widoczne w aplikacji (Pusher).
+- Automatyczna kategoryzacja przy `POST /items` używa bazy produktów rodziny
+  (i opcjonalnie embeddingów OpenAI). Przy `POST /items/bulk` embeddingi są
+  pomijane dla szybkości — podawaj `category` jawnie, jeśli zależy Ci na
+  kategoriach.

--- a/drizzle/migration_api_keys.sql
+++ b/drizzle/migration_api_keys.sql
@@ -1,0 +1,17 @@
+-- =============================================================================
+-- Migration: Add api_keys table (per-family keys for the agent REST API)
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS public.api_keys (
+  id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  family_id        UUID NOT NULL REFERENCES public.families(id) ON DELETE CASCADE,
+  agent_profile_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  name             TEXT NOT NULL DEFAULT 'Agent',
+  key_hash         TEXT NOT NULL UNIQUE,
+  key_prefix       TEXT NOT NULL,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_used_at     TIMESTAMPTZ,
+  revoked_at       TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_api_keys_family_id ON public.api_keys(family_id);

--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -1,0 +1,71 @@
+import { createHash, randomBytes } from 'crypto';
+import { NextRequest, NextResponse } from 'next/server';
+import { eq, and, isNull } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { apiKeys } from '@/lib/db/schema';
+
+export const API_KEY_PREFIX = 'cartlo_sk_';
+
+export type ApiKeyContext = {
+  keyId: string;
+  familyId: string;
+  agentProfileId: string;
+};
+
+export function generateApiKeyString(): string {
+  return API_KEY_PREFIX + randomBytes(32).toString('base64url');
+}
+
+/**
+ * SHA-256 (not bcrypt) so the hash is deterministic and the key can be found
+ * via the unique index in O(1). The secret carries 256 random bits, so
+ * brute-forcing the hash is infeasible.
+ */
+export function hashApiKey(key: string): string {
+  return createHash('sha256').update(key).digest('hex');
+}
+
+/**
+ * Authenticate an agent request via `Authorization: Bearer cartlo_sk_...`.
+ * Returns null for missing/unknown/revoked keys.
+ */
+export async function authenticateApiKey(
+  request: NextRequest,
+): Promise<ApiKeyContext | null> {
+  const authHeader = request.headers.get('authorization');
+  if (!authHeader?.startsWith('Bearer ')) return null;
+
+  const key = authHeader.slice('Bearer '.length).trim();
+  if (!key.startsWith(API_KEY_PREFIX)) return null;
+
+  const [row] = await db
+    .select({
+      id: apiKeys.id,
+      familyId: apiKeys.familyId,
+      agentProfileId: apiKeys.agentProfileId,
+    })
+    .from(apiKeys)
+    .where(and(eq(apiKeys.keyHash, hashApiKey(key)), isNull(apiKeys.revokedAt)))
+    .limit(1);
+
+  if (!row) return null;
+
+  // Fire-and-forget — auth must not fail or slow down on bookkeeping
+  db.update(apiKeys)
+    .set({ lastUsedAt: new Date() })
+    .where(eq(apiKeys.id, row.id))
+    .then(
+      () => {},
+      () => {},
+    );
+
+  return {
+    keyId: row.id,
+    familyId: row.familyId,
+    agentProfileId: row.agentProfileId,
+  };
+}
+
+export function unauthorized(): NextResponse {
+  return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+}

--- a/lib/api/serialize.ts
+++ b/lib/api/serialize.ts
@@ -1,0 +1,52 @@
+import type { CategoryInfo, ShoppingItemRow } from '@/lib/shopping/service';
+
+export type ApiShoppingItem = {
+  id: string;
+  product_name: string;
+  category_id: string | null;
+  category_name: string | null;
+  category_icon: string | null;
+  quantity: number;
+  unit: string;
+  is_checked: boolean;
+  added_by_name: string | null;
+  checked_by_name: string | null;
+  created_at: string;
+  checked_at: string | null;
+};
+
+export function toApiItem(
+  item: ShoppingItemRow,
+  categoryById: Record<string, CategoryInfo>,
+  memberNames: Record<string, string>,
+): ApiShoppingItem {
+  const category = item.categoryId
+    ? (categoryById[item.categoryId] ?? null)
+    : null;
+  return {
+    id: item.id,
+    product_name: item.productName,
+    category_id: item.categoryId,
+    category_name: category?.name ?? null,
+    category_icon: category?.icon ?? null,
+    quantity: parseFloat(item.quantity),
+    unit: item.unit,
+    is_checked: item.isChecked,
+    added_by_name: memberNames[item.addedBy] ?? null,
+    checked_by_name: item.checkedBy
+      ? (memberNames[item.checkedBy] ?? null)
+      : null,
+    created_at: item.createdAt.toISOString(),
+    checked_at: item.checkedAt?.toISOString() ?? null,
+  };
+}
+
+export function buildCategoryById(
+  cats: CategoryInfo[],
+): Record<string, CategoryInfo> {
+  const byId: Record<string, CategoryInfo> = {};
+  cats.forEach((c) => {
+    byId[c.id] = c;
+  });
+  return byId;
+}

--- a/lib/api/validate.ts
+++ b/lib/api/validate.ts
@@ -1,0 +1,90 @@
+import { MAX_QUANTITY, VALID_UNITS } from '@/lib/shopping/service';
+
+export const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export type ItemInput = {
+  productName: string;
+  quantity?: number;
+  unit?: string;
+  categoryName?: string | null;
+};
+
+export type ValidationResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: string };
+
+/**
+ * Validate the shared item payload shape used by POST /items and each entry
+ * of POST /items/bulk: { product_name, quantity?, unit?, category? }.
+ */
+export function validateItemInput(
+  body: Record<string, unknown>,
+): ValidationResult<ItemInput> {
+  const rawName = body.product_name;
+  if (typeof rawName !== 'string' || rawName.trim().length === 0) {
+    return { ok: false, error: 'product_name is required' };
+  }
+  const productName = rawName.trim();
+  if (productName.length > 100) {
+    return { ok: false, error: 'product_name must be at most 100 characters' };
+  }
+
+  const result: ItemInput = { productName };
+
+  if (body.quantity !== undefined) {
+    const quantityError = validateQuantity(body.quantity);
+    if (quantityError) return { ok: false, error: quantityError };
+    result.quantity = body.quantity as number;
+  }
+
+  if (body.unit !== undefined) {
+    const unitError = validateUnit(body.unit);
+    if (unitError) return { ok: false, error: unitError };
+    result.unit = body.unit as string;
+  }
+
+  if (body.category !== undefined && body.category !== null) {
+    if (typeof body.category !== 'string') {
+      return { ok: false, error: 'category must be a string' };
+    }
+    result.categoryName = body.category.trim() || null;
+  }
+
+  return { ok: true, value: result };
+}
+
+export function validateQuantity(value: unknown): string | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return 'quantity must be a number';
+  }
+  if (value <= 0 || value > MAX_QUANTITY) {
+    return `quantity must be greater than 0 and at most ${MAX_QUANTITY}`;
+  }
+  return null;
+}
+
+export function validateUnit(value: unknown): string | null {
+  if (
+    typeof value !== 'string' ||
+    !(VALID_UNITS as readonly string[]).includes(value)
+  ) {
+    return `unit must be one of: ${VALID_UNITS.join(', ')}`;
+  }
+  return null;
+}
+
+/** Parse a request body as a JSON object; returns null on invalid JSON. */
+export async function parseJsonBody(
+  request: Request,
+): Promise<Record<string, unknown> | null> {
+  try {
+    const body = await request.json();
+    if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+      return null;
+    }
+    return body as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -130,6 +130,28 @@ export const templateItems = pgTable('template_items', {
   sortOrder: integer('sort_order').notNull().default(0),
 });
 
+export const apiKeys = pgTable(
+  'api_keys',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    familyId: uuid('family_id')
+      .notNull()
+      .references(() => families.id, { onDelete: 'cascade' }),
+    agentProfileId: uuid('agent_profile_id')
+      .notNull()
+      .references(() => profiles.id, { onDelete: 'cascade' }),
+    name: text('name').notNull().default('Agent'),
+    keyHash: text('key_hash').notNull().unique(),
+    keyPrefix: text('key_prefix').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    lastUsedAt: timestamp('last_used_at', { withTimezone: true }),
+    revokedAt: timestamp('revoked_at', { withTimezone: true }),
+  },
+  (table) => [index('idx_api_keys_family_id').on(table.familyId)],
+);
+
 export const shoppingItems = pgTable(
   'shopping_items',
   {

--- a/lib/shopping/service.ts
+++ b/lib/shopping/service.ts
@@ -1,0 +1,437 @@
+import { eq, and, or, isNull, ilike, asc, sql, inArray } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { shoppingItems, categories, products, profiles } from '@/lib/db/schema';
+import { notifyListUpdate } from '@/lib/pusher/server';
+import { removeDiacritics } from '@/lib/utils';
+import {
+  generateEmbedding,
+  findSimilarProducts,
+  saveProductEmbedding,
+  upsertProductEmbedding,
+  isEmbeddingConfigured,
+} from '@/lib/embeddings';
+
+// ---------------------------------------------------------------------------
+// Shared constants & types
+// ---------------------------------------------------------------------------
+
+export const VALID_UNITS = ['szt', 'g', 'kg', 'ml', 'l'] as const;
+// quantity is NUMERIC(10,2) — cap at what the column can hold sensibly
+export const MAX_QUANTITY = 9999.99;
+
+export type ShoppingItemRow = typeof shoppingItems.$inferSelect;
+
+export type CategoryInfo = { id: string; name: string; icon: string };
+
+export type UpdateItemPatch = {
+  productName?: string;
+  quantity?: number;
+  unit?: string;
+  categoryId?: string | null;
+  isChecked?: boolean;
+};
+
+export type BulkItemInput = {
+  productName: string;
+  categoryName?: string | null;
+  quantity?: number;
+  unit?: string;
+};
+
+// ---------------------------------------------------------------------------
+// Lookups
+// ---------------------------------------------------------------------------
+
+/** All categories visible to a family (global defaults + family-specific). */
+export async function getFamilyCategories(
+  familyId: string,
+): Promise<(CategoryInfo & { sortOrder: number })[]> {
+  const cats = await db
+    .select({
+      id: categories.id,
+      name: categories.name,
+      icon: categories.icon,
+      sortOrder: categories.sortOrder,
+    })
+    .from(categories)
+    .where(or(isNull(categories.familyId), eq(categories.familyId, familyId)))
+    .orderBy(asc(categories.sortOrder));
+  return cats;
+}
+
+/**
+ * Case- and diacritic-insensitive category name lookup
+ * (same matching rules as template import: "Nabiał" ≡ "nabial").
+ */
+export function buildCategoryNameIndex(
+  cats: CategoryInfo[],
+): Record<string, CategoryInfo> {
+  const byName: Record<string, CategoryInfo> = {};
+  cats.forEach((c) => {
+    byName[c.name.toLowerCase()] = c;
+    byName[removeDiacritics(c.name).toLowerCase()] = c;
+  });
+  return byName;
+}
+
+export function matchCategoryByName(
+  index: Record<string, CategoryInfo>,
+  name: string,
+): CategoryInfo | null {
+  return (
+    index[name.toLowerCase()] ??
+    index[removeDiacritics(name).toLowerCase()] ??
+    null
+  );
+}
+
+/** Display names of family members keyed by profile id. */
+export async function getMemberNames(
+  familyId: string,
+): Promise<Record<string, string>> {
+  const members = await db
+    .select({ id: profiles.id, displayName: profiles.displayName })
+    .from(profiles)
+    .where(eq(profiles.familyId, familyId));
+
+  const names: Record<string, string> = {};
+  members.forEach((m) => {
+    names[m.id] = m.displayName;
+  });
+  return names;
+}
+
+// ---------------------------------------------------------------------------
+// Read
+// ---------------------------------------------------------------------------
+
+export async function getShoppingList(familyId: string): Promise<{
+  items: ShoppingItemRow[];
+  categories: (CategoryInfo & { sortOrder: number })[];
+  memberNames: Record<string, string>;
+}> {
+  const [items, cats, memberNames] = await Promise.all([
+    db
+      .select()
+      .from(shoppingItems)
+      .where(eq(shoppingItems.familyId, familyId))
+      .orderBy(asc(shoppingItems.productName)),
+    getFamilyCategories(familyId),
+    getMemberNames(familyId),
+  ]);
+
+  return { items, categories: cats, memberNames };
+}
+
+// ---------------------------------------------------------------------------
+// Mutations
+// ---------------------------------------------------------------------------
+
+export type AddItemResult =
+  | { ok: true; item: ShoppingItemRow }
+  | { ok: false; error: 'duplicate'; itemId: string };
+
+/**
+ * Add a single item to the family's list. When `categoryId` is undefined the
+ * category is auto-detected from the products table (exact match first, then
+ * semantic search via embeddings), teaching the products table as a side
+ * effect — same behavior the in-app "add product" flow has always had.
+ */
+export async function addShoppingItem(params: {
+  familyId: string;
+  profileId: string;
+  productName: string;
+  quantity?: number;
+  unit?: string;
+  categoryId?: string | null;
+}): Promise<AddItemResult> {
+  const { familyId, profileId } = params;
+  const trimmed = params.productName.trim();
+
+  // Check for duplicates on active list
+  const existing = await db
+    .select({ id: shoppingItems.id })
+    .from(shoppingItems)
+    .where(
+      and(
+        eq(shoppingItems.familyId, familyId),
+        eq(shoppingItems.isChecked, false),
+        ilike(shoppingItems.productName, trimmed),
+      ),
+    )
+    .limit(1);
+
+  if (existing.length > 0) {
+    return { ok: false, error: 'duplicate', itemId: existing[0].id };
+  }
+
+  // Determine category: use known category if provided, otherwise auto-detect
+  let categoryId: string | null = params.categoryId ?? null;
+
+  if (params.categoryId === undefined) {
+    const [knownProduct] = await db
+      .select({
+        id: products.id,
+        categoryId: products.categoryId,
+        usageCount: products.usageCount,
+      })
+      .from(products)
+      .where(
+        and(
+          ilike(products.name, trimmed),
+          or(isNull(products.familyId), eq(products.familyId, familyId)),
+        ),
+      )
+      .limit(1);
+
+    if (knownProduct) {
+      categoryId = knownProduct.categoryId;
+      // Increment usage_count for better autocomplete sorting
+      await db
+        .update(products)
+        .set({ usageCount: knownProduct.usageCount + 1 })
+        .where(eq(products.id, knownProduct.id));
+    } else {
+      // Product not found by exact match — try semantic search via embeddings
+      let embeddingCategoryId: string | null = null;
+      let productEmbedding: number[] | null = null;
+
+      if (isEmbeddingConfigured()) {
+        try {
+          productEmbedding = await generateEmbedding(trimmed);
+          const similar = await findSimilarProducts(
+            productEmbedding,
+            familyId,
+            {
+              threshold: 0.8,
+              limit: 1,
+              requireCategory: true,
+            },
+          );
+
+          if (similar.length > 0 && similar[0].categoryId) {
+            embeddingCategoryId = similar[0].categoryId;
+          }
+        } catch (err) {
+          console.error('[addShoppingItem] Embedding generation failed:', err);
+        }
+      }
+
+      categoryId = embeddingCategoryId;
+
+      // Add as new product (with embedding if available)
+      try {
+        const [newProduct] = await db
+          .insert(products)
+          .values({
+            name: trimmed,
+            categoryId,
+            familyId,
+            usageCount: 1,
+          })
+          .onConflictDoUpdate({
+            target: [products.name, products.familyId],
+            set: { categoryId, usageCount: sql`${products.usageCount} + 1` },
+          })
+          .returning({ id: products.id });
+
+        // Save embedding for the new product (non-blocking)
+        if (isEmbeddingConfigured() && newProduct) {
+          if (productEmbedding) {
+            saveProductEmbedding(newProduct.id, productEmbedding).catch(
+              () => {},
+            );
+          } else {
+            upsertProductEmbedding(newProduct.id, trimmed).catch(() => {});
+          }
+        }
+      } catch {
+        // Product upsert failed — continue with shopping item insertion
+      }
+    }
+  }
+
+  const [item] = await db
+    .insert(shoppingItems)
+    .values({
+      familyId,
+      productName: trimmed,
+      categoryId,
+      quantity: (params.quantity ?? 1).toString(),
+      unit: params.unit ?? 'szt',
+      addedBy: profileId,
+    })
+    .returning();
+
+  notifyListUpdate(familyId);
+  return { ok: true, item };
+}
+
+/**
+ * Update an item, always scoped to the family (id alone is never trusted).
+ * Returns the updated row, or null when the item doesn't belong to the family.
+ */
+export async function updateShoppingItem(params: {
+  familyId: string;
+  itemId: string;
+  patch: UpdateItemPatch;
+  /** Profile credited as checkedBy when the patch checks the item. */
+  actorProfileId: string;
+}): Promise<ShoppingItemRow | null> {
+  const { familyId, itemId, patch, actorProfileId } = params;
+
+  const updateSet: Partial<typeof shoppingItems.$inferInsert> = {};
+
+  if (patch.productName !== undefined) {
+    updateSet.productName = patch.productName.trim();
+  }
+  if (patch.quantity !== undefined) {
+    updateSet.quantity = patch.quantity.toString();
+  }
+  if (patch.unit !== undefined) {
+    updateSet.unit = patch.unit;
+  }
+  if (patch.categoryId !== undefined) {
+    updateSet.categoryId = patch.categoryId;
+  }
+  if (patch.isChecked !== undefined) {
+    updateSet.isChecked = patch.isChecked;
+    updateSet.checkedBy = patch.isChecked ? actorProfileId : null;
+    updateSet.checkedAt = patch.isChecked ? new Date() : null;
+  }
+
+  if (Object.keys(updateSet).length === 0) return null;
+
+  const [item] = await db
+    .update(shoppingItems)
+    .set(updateSet)
+    .where(
+      and(eq(shoppingItems.id, itemId), eq(shoppingItems.familyId, familyId)),
+    )
+    .returning();
+
+  if (!item) return null;
+
+  notifyListUpdate(familyId);
+  return item;
+}
+
+/** Delete an item scoped to the family. Returns false when not found. */
+export async function deleteShoppingItem(params: {
+  familyId: string;
+  itemId: string;
+}): Promise<boolean> {
+  const { familyId, itemId } = params;
+
+  const deleted = await db
+    .delete(shoppingItems)
+    .where(
+      and(eq(shoppingItems.id, itemId), eq(shoppingItems.familyId, familyId)),
+    )
+    .returning({ id: shoppingItems.id });
+
+  if (deleted.length === 0) return false;
+
+  notifyListUpdate(familyId);
+  return true;
+}
+
+/**
+ * Add a whole list of items in one shot (agent bulk import). Duplicates —
+ * against the active list and within the batch — are skipped, not errors.
+ * Categories are matched by name (diacritic-insensitive) with a products-table
+ * fallback. Embeddings are intentionally skipped: generating N embeddings in
+ * one serverless request is too slow.
+ */
+export async function bulkAddShoppingItems(params: {
+  familyId: string;
+  profileId: string;
+  items: BulkItemInput[];
+}): Promise<{ added: ShoppingItemRow[]; skipped: string[] }> {
+  const { familyId, profileId } = params;
+
+  const cats = await getFamilyCategories(familyId);
+  const categoryIndex = buildCategoryNameIndex(cats);
+
+  const activeItems = await db
+    .select({ productName: shoppingItems.productName })
+    .from(shoppingItems)
+    .where(
+      and(
+        eq(shoppingItems.familyId, familyId),
+        eq(shoppingItems.isChecked, false),
+      ),
+    );
+
+  const seenNames = new Set(
+    activeItems.map((i) => i.productName.toLowerCase()),
+  );
+
+  // Resolve product-table categories for all names in a single query
+  const inputNames = params.items
+    .map((i) => i.productName.trim())
+    .filter(Boolean);
+
+  const productCategoryByName: Record<string, string | null> = {};
+  if (inputNames.length > 0) {
+    const knownProducts = await db
+      .select({ name: products.name, categoryId: products.categoryId })
+      .from(products)
+      .where(
+        and(
+          inArray(
+            sql`lower(${products.name})`,
+            inputNames.map((n) => n.toLowerCase()),
+          ),
+          or(isNull(products.familyId), eq(products.familyId, familyId)),
+        ),
+      );
+    knownProducts.forEach((p) => {
+      // Family-specific products override global ones on name collisions;
+      // either way any match beats "no category"
+      productCategoryByName[p.name.toLowerCase()] ??= p.categoryId;
+    });
+  }
+
+  const skipped: string[] = [];
+  const toInsert: (typeof shoppingItems.$inferInsert)[] = [];
+
+  for (const input of params.items) {
+    const name = input.productName.trim();
+    if (!name) continue;
+
+    if (seenNames.has(name.toLowerCase())) {
+      skipped.push(name);
+      continue;
+    }
+    seenNames.add(name.toLowerCase());
+
+    const matchedCategory = input.categoryName
+      ? matchCategoryByName(categoryIndex, input.categoryName)
+      : null;
+    const categoryId =
+      matchedCategory?.id ?? productCategoryByName[name.toLowerCase()] ?? null;
+
+    const quantity = input.quantity && input.quantity > 0 ? input.quantity : 1;
+    const unit =
+      input.unit && (VALID_UNITS as readonly string[]).includes(input.unit)
+        ? input.unit
+        : 'szt';
+
+    toInsert.push({
+      familyId,
+      productName: name,
+      categoryId,
+      quantity: quantity.toString(),
+      unit,
+      addedBy: profileId,
+    });
+  }
+
+  if (toInsert.length === 0) return { added: [], skipped };
+
+  const added = await db.insert(shoppingItems).values(toInsert).returning();
+
+  notifyListUpdate(familyId);
+  return { added, skipped };
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,16 @@ import { twMerge } from 'tailwind-merge';
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/**
+ * Strip diacritics so that e.g. "Nabiał" matches "Nabial".
+ * "ł"/"Ł" need explicit mapping — the stroke is not a combining mark,
+ * so NFD normalization leaves it untouched.
+ */
+export function removeDiacritics(str: string): string {
+  return str
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/ł/g, 'l')
+    .replace(/Ł/g, 'L');
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,7 +2,16 @@ import { auth } from '@/lib/auth';
 import { NextResponse } from 'next/server';
 
 // Routes accessible without authentication
-const PUBLIC_ROUTES = ['/login', '/join', '/api/auth', '/api/seed', '/api/embeddings/seed'];
+// /api/v1 is the agent API — it enforces its own Bearer key auth and must
+// return 401 JSON instead of redirecting to /login
+const PUBLIC_ROUTES = [
+  '/login',
+  '/join',
+  '/api/auth',
+  '/api/seed',
+  '/api/embeddings/seed',
+  '/api/v1',
+];
 
 export default auth((req) => {
   const { pathname } = req.nextUrl;


### PR DESCRIPTION
Expose the family shopping list over HTTP so an external agent can read
and edit it with a per-family API key kept in the agent's env file:

- GET /api/v1/list, POST/PATCH/DELETE /api/v1/items(/:id) and
  POST /api/v1/items/bulk (whole list at once, duplicates skipped)
- api_keys table: per-family keys (SHA-256 hashed, shown once,
  soft-revocable) resolved to familyId + a system "Agent" profile
  backed by a synthetic non-loginable user, so list items show
  proper attribution in the app
- key management card in Settings (generate/revoke, show-once dialog)
- shared lib/shopping/service.ts extracted from server actions and
  page queries; server actions are now thin session wrappers, which
  also fixes the missing family scoping (IDOR) in updateQuantity
- /api/v1 exempted from session middleware; routes enforce Bearer auth
  and return 401 JSON instead of redirecting
- removeDiacritics moved to lib/utils and fixed to also map ł/Ł,
  which NFD normalization leaves untouched
- docs/api.md with endpoint reference and curl examples

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VqaKKRas7DM5DaM6pzgg6L